### PR TITLE
Debounce search input

### DIFF
--- a/schema_obj.js
+++ b/schema_obj.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var util = require('./util');
+
+module.exports = SchemaObject;
+
+function SchemaObject(obj) {
+  util.copy(obj, this);
+}


### PR DESCRIPTION
Adds a 300ms debounce to the global search input to reduce API calls and avoid spamming requests while typing. Implements a reusable useDebouncedValue hook and updates SearchBar to use it.