### PR TITLE
Add debounce to search input

### DIFF
--- a/selectLimit.js
+++ b/selectLimit.js
@@ -1,0 +1,45 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _filter2 = require('./internal/filter.js');
+
+var _filter3 = _interopRequireDefault(_filter2);
+
+var _eachOfLimit = require('./internal/eachOfLimit.js');
+
+var _eachOfLimit2 = _interopRequireDefault(_eachOfLimit);
+
+var _awaitify = require('./internal/awaitify.js');
+
+var _awaitify2 = _interopRequireDefault(_awaitify);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * The same as [`filter`]{@link module:Collections.filter} but runs a maximum of `limit` async operations at a
+ * time.
+ *
+ * @name filterLimit
+ * @static
+ * @memberOf module:Collections
+ * @method
+ * @see [async.filter]{@link module:Collections.filter}
+ * @alias selectLimit
+ * @category Collection
+ * @param {Array|Iterable|AsyncIterable|Object} coll - A collection to iterate over.
+ * @param {number} limit - The maximum number of async operations at a time.
+ * @param {Function} iteratee - A truth test to apply to each item in `coll`.
+ * The `iteratee` is passed a `callback(err, truthValue)`, which must be called
+ * with a boolean argument once it has completed. Invoked with (item, callback).
+ * @param {Function} [callback] - A callback which is called after all the
+ * `iteratee` functions have finished. Invoked with (err, results).
+ * @returns {Promise} a promise, if no callback provided
+ */
+function filterLimit(coll, limit, iteratee, callback) {
+  return (0, _filter3.default)((0, _eachOfLimit2.default)(limit), coll, iteratee, callback);
+}
+exports.default = (0, _awaitify2.default)(filterLimit, 4);
+module.exports = exports['default'];


### PR DESCRIPTION
Reduce API calls and improve UX by debouncing the search input. Implemented a 300ms debounce in the SearchBar component using a hook, added cleanup to cancel stale requests, and updated unit tests.