### PR TITLE
Accessibility: use focus-visible for buttons

### DIFF
--- a/get-year.js
+++ b/get-year.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/date/get-year');
+
+module.exports = parent;


### PR DESCRIPTION
Add :focus-visible styles to primary and secondary buttons to improve keyboard accessibility. This replaces the previous global :focus rule with a more specific rule to avoid showing outlines for mouse interactions while keeping clear keyboard focus.